### PR TITLE
Chainable public api.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## 1.0.1 (3 December 2020)
+
+### Improvements
+
+- Adding `chain` option to manager api methods.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readiness-manager",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "👨‍💼 Define when your app is ready",
   "keywords": [
     "ready",

--- a/src/index.js
+++ b/src/index.js
@@ -97,11 +97,11 @@ class ReadinessManager {
     onReady(callback) {
         if (readyState) {
             // Invokes immediately given callback if process is already ready.
-            return callback();
+            callback();
+            return this;
         }
 
         this[Symbols.callbacks].push(callback);
-
         return this;
     }
 
@@ -121,7 +121,6 @@ class ReadinessManager {
         }
 
         this[Symbols.beacons][name].callbacks.push(callback);
-
         return this;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const Symbols = [
 let readyState = false;
 
 /**
- * @type ReadinessManager
+ * @type {ReadinessManager}
  */
 class ReadinessManager {
     constructor() {
@@ -78,17 +78,21 @@ class ReadinessManager {
 
     /**
      * Runs current registered beacons execution to determine process "ready" state.
+     * @return {ReadinessManager}
      */
     run() {
         readyState = false;
 
         Object.values(this[Symbols.beacons])
             .map(this[Symbols.execute]);
+
+        return this;
     }
 
     /**
      * Registers a given callback to be triggered once process is marked as "ready".
      * @param {ReadyCallback} callback
+     * @return {ReadinessManager}
      */
     onReady(callback) {
         if (readyState) {
@@ -97,12 +101,15 @@ class ReadinessManager {
         }
 
         this[Symbols.callbacks].push(callback);
+
+        return this;
     }
 
     /**
      * Registers a given callback on a specific action resolved..
      * @param {string} name - The name of the action the callback should be attached to.
      * @param {ReadyCallback} callback - The callback to run upon beacon resolved.
+     * @return {ReadinessManager}
      */
     onActionReady(name, callback) {
         const beacon = this[Symbols.beacons][name];
@@ -114,14 +121,18 @@ class ReadinessManager {
         }
 
         this[Symbols.beacons][name].callbacks.push(callback);
+
+        return this;
     }
 
     /**
      * Registers a given error handler under manager errors.
      * @param {ActionErrorHandler} errorHandler - The handler to trigger upon action errors.
+     * @return {ReadinessManager}
      */
     onError(errorHandler) {
         Object.assign(this, { [Symbols.errorHandler]: errorHandler });
+        return this;
     }
 
     /**

--- a/src/spec.js
+++ b/src/spec.js
@@ -256,13 +256,16 @@ describe('lib/readinessManager', () => {
     describe('Chainable', () => {
         it('Expose public chainable api', () => {
             const ready = jest.fn();
+            const error = jest.fn();
 
             readyManager.register('action', () => true);
 
             readyManager.run()
-                .onReady(ready);
+                .onReady(ready)
+                .onError(error);
 
             expect(ready).toHaveBeenCalledTimes(1);
+            expect(error).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/src/spec.js
+++ b/src/spec.js
@@ -252,4 +252,17 @@ describe('lib/readinessManager', () => {
             });
         });
     });
+
+    describe('Chainable', () => {
+        it('Expose public chainable api', () => {
+            const ready = jest.fn();
+
+            readyManager.register('action', () => true);
+
+            readyManager.run()
+                .onReady(ready);
+
+            expect(ready).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/src/spec.js
+++ b/src/spec.js
@@ -260,9 +260,9 @@ describe('lib/readinessManager', () => {
 
             readyManager.register('action', () => true);
 
-            readyManager.run()
+            const x = readyManager.run()
                 .onReady(ready)
-                .onError(error);
+                .onError(error)
 
             expect(ready).toHaveBeenCalledTimes(1);
             expect(error).toHaveBeenCalledTimes(0);

--- a/src/spec.js
+++ b/src/spec.js
@@ -260,9 +260,9 @@ describe('lib/readinessManager', () => {
 
             readyManager.register('action', () => true);
 
-            const x = readyManager.run()
+            readyManager.run()
                 .onReady(ready)
-                .onError(error)
+                .onError(error);
 
             expect(ready).toHaveBeenCalledTimes(1);
             expect(error).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
**Main changes:**
- Most of public api now return a self instance allowing consumer to do the following syntax :
```
ReadinessManager.run()
    .onReady(...)
    .onError(...)
```

**Side effects**
- Adding changelog.