### PR TITLE
Enriching errors with attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 1.0.2 (7 December 2020)
+## 1.1.0 (6 December 2020)
 
 - Adding `attempt` over `ActionExecutionError`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 1.1.0 (6 December 2020)
+## 1.1.0 (7 December 2020)
 
 - Adding `attempt` over `ActionExecutionError`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.0.2 (7 December 2020)
+
+- Adding `attempt` over `ActionExecutionError`.
+
 ## 1.0.1 (3 December 2020)
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -77,9 +77,16 @@ Registers a given callback on a specific action completion event.
 ### onError(errorHandler: ActionErrorHandler): void
 
 ```ts
-type ActionErrorHandler = (error: ActionExecutionError, retry: ActionRetry) => void;
+interface ActionExecutionError extends Error {
+    name: string;
+    stack: string;
+    attempt: number;
+    failReason: string;
+}
 
 type ActionRetry = () => Promise<void>;
+
+type ActionErrorHandler = (error: ActionExecutionError, retry: ActionRetry) => void;
 ```
 
 Registers given error handler under the `ReadinessManager`. Any error that will be thrown from execution one of the registered actions will trigger this handler.
@@ -121,7 +128,7 @@ ReadinessManager.register('action', unstableAction);
 
 ReadinessManager.onError((error, retry) => {
    console.log(error);
-   if (count <= 1) retry();
+   if (error.attempt <= 1) retry();
 });
 
 ReadinessManager.run();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readiness-manager",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "👨‍💼 Define when your app is ready",
   "keywords": [
     "ready",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readiness-manager",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "👨‍💼 Define when your app is ready",
   "keywords": [
     "ready",

--- a/src/error.js
+++ b/src/error.js
@@ -13,12 +13,13 @@ const ERRORS = {
  * @type {ActionExecutionError}
  */
 class ActionExecutionError extends Error {
-    constructor(name, error) {
+    constructor(name, attempt, error) {
         super();
 
         Object.assign(this, {
             message: ERRORS.BEACON_EXECUTION_FAILED,
             name,
+            attempt,
             stack: error.stack,
             failReason: error.message
         });

--- a/src/index.js
+++ b/src/index.js
@@ -135,12 +135,13 @@ class ReadinessManager {
     }
 
     /**
-     * Tracks a given beacon action
-     * @param {Beacon} beacon
+     * Tracks a given beacon action.
+     * @param {Beacon} beacon - The beacon to execute.
+     * @param {Number} attempt - The attempt number of current beacon execution.
      * @throws {ActionExecutionError}
      * @private
      */
-    async [Symbols.execute](beacon) {
+    async [Symbols.execute](beacon, attempt = 1) {
         const { name, action } = beacon;
 
         const update = (status) => this[Symbols.updateBeacon](name, status);
@@ -161,8 +162,8 @@ class ReadinessManager {
 
             // Invokes consumer error hook with a retry method and the beacon error.
             this[Symbols.errorHandler](
-                new ActionExecutionError(name, error),
-                () => this[Symbols.execute](beacon)
+                new ActionExecutionError(name, attempt, error),
+                () => this[Symbols.execute](beacon, attempt + 1)
             );
         }
     }

--- a/src/spec.js
+++ b/src/spec.js
@@ -247,7 +247,7 @@ describe('lib/readinessManager', () => {
 
             it('Triggers consumer handler with beacon execution error', () => {
                 expect(logger).toHaveBeenCalledWith(
-                    new ActionExecutionError('success', error)
+                    new ActionExecutionError('success', 0, error)
                 );
             });
         });

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -15,6 +15,7 @@ type BeaconsMap = { [name: string] : Beacon };
 interface ActionExecutionError extends Error {
     name: string;
     stack: string;
+    attempt: number;
     failReason: string;
 }
 


### PR DESCRIPTION
Can be used by consumer to have better error handling flow, e.g:

```js
onError((error, retry) => {
    if (error.attempt >= MAX_ATTEMPS) {
        logger.warn(`Action  ${error.name} failed for the ${erro.attempt} time`);
         return retry();
    }
     logger.critical(error);
})
```

Each execution will aggregate it's last attempt.