### PR TITLE
[FIX] Fix beacon initial execution attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.4 (7 April 2022)
+
+- Fix beacon initial execution, attempt was passed as index of the `forEach`.
+
 ## 1.1.3 (2 August 2021)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readiness-manager",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "👨‍💼 Define when your app is ready",
   "keywords": [
     "ready",

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class ReadinessManager {
         readyState = false;
 
         Object.values(this[Symbols.beacons])
-            .map((beacon) => this[Symbols.execute](beacon));
+            .forEach((beacon) => this[Symbols.execute](beacon));
 
         return this;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class ReadinessManager {
         readyState = false;
 
         Object.values(this[Symbols.beacons])
-            .map(this[Symbols.execute]);
+            .map((beacon) => this[Symbols.execute](beacon));
 
         return this;
     }


### PR DESCRIPTION
Yea... `forEach` was passing the index as attempt, which created nasty issue.